### PR TITLE
fix listing of host applications

### DIFF
--- a/com.github.donadigo.appeditor.json
+++ b/com.github.donadigo.appeditor.json
@@ -13,6 +13,7 @@
         /* Wayland */
         "--socket=wayland",
         "--filesystem=host:ro",
+        "--filesystem=xdg-data/applications:ro",
         "--filesystem=xdg-data/applications:create",
         /* dconf */
         "--metadata=X-DConf=migrate-path=/com/github/donadigo/appeditor/"


### PR DESCRIPTION
Fix listing of host applications.

https://github.com/flathub/com.github.donadigo.appeditor/pull/16 required first for CI to pass

Except for flatpak apps see https://github.com/flathub/com.github.donadigo.appeditor/issues/18