### PR TITLE
fix desktop file rewrite

### DIFF
--- a/com.github.donadigo.appeditor.json
+++ b/com.github.donadigo.appeditor.json
@@ -49,7 +49,7 @@
                 }
             ],
             "post-install": [
-                "sed -i s:Exec=data/com.github.donadigo.appeditor:Exec=/app/bin/appeditor-wrapper: /app/share/applications/com.github.donadigo.appeditor.desktop"
+                "desktop-file-edit --set-key=Exec --set-value=/app/bin/appeditor-wrapper /app/share/applications/com.github.donadigo.appeditor.desktop"
             ]
         }
     ]


### PR DESCRIPTION
Listing host applications is broken due to the wrapper not being used in the desktop file.

AppEditor desktop file never had (according to blame) `Exec=data/com.github.donadigo.appeditor` but `Exec=com.github.donadigo.appeditor`.

Not sure how this ever worked.

AppEditor correctly list host applications with this change.